### PR TITLE
Add instructions to build and run the executable in a Docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,21 @@ $ cd should-i-watch-this
 $ shards build --release
 ```
 
+### Using Docker
+
+```bash
+$ git clone git@github.com:koffeinfrei/should-i-watch-this.git
+$ cd should-i-watch-this
+$ docker run -it \
+  -v $PWD:/app \
+  -v $HOME/.config/should-i-watch-this:/root/.config/should-i-watch-this \
+  -w /app \
+  crystallang/crystal /bin/bash
+
+# Then, inside Docker container:
+$ shards build --release
+```
+
 ## Usage
 
 ```bash

--- a/src/configuration.cr
+++ b/src/configuration.cr
@@ -1,5 +1,5 @@
 class Configuration
-  getter config_file : String = Path.home.join(".config", ".should-i-watch-this").to_s
+  getter config_file : String = Path.home.join(".config", "should-i-watch-this", "omdb-api-key").to_s
 
   def key
     File.read(config_file)


### PR DESCRIPTION
A few compromises have to be taken here:
- with the instructions as they are (no `-u` option in the `docker run` command), the user who builds the executable is `root`. Therefore, when exiting the container, the _bin_ and _lib_ folders, as well as the configuration file containing the OMDb API key, all belong to `root` and must be deleted with `sudo`.
- if we specify `-u $(id -u):$(id -g)` in the `docker run` options, these files don't belong to `root` but to the user running the container (**good**), but then that user has no `$HOME` folder, so the configuration file cannot be created.

In the end, the current proposal is probably the most acceptable one.  
Critique/alternative proposals are welcome.